### PR TITLE
Introduce the Update URI to the plugin header

### DIFF
--- a/broken-link-checker.php
+++ b/broken-link-checker.php
@@ -10,6 +10,7 @@
  * Text Domain: broken-link-checker
  * License:     GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Update URI:  https://github.com/mehigh/broken-link-checker
 */
 
 /*


### PR DESCRIPTION
When using this plugin, WordPress confuses it with [this .org hosted plugin](https://wordpress.org/plugins/broken-link-checker/) resulting in it showing an update being available when there isn't.

This change leverages the [new Update URI plugin header](https://make.wordpress.org/core/2021/06/29/introducing-update-uri-plugin-header-in-wordpress-5-8/) to prevent this happening.